### PR TITLE
Update mountpoints in fstab.yaml to use Dark Alley

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--{repo}--{owner}.aem.live/
-- After: https://<branch>--{repo}--{owner}.aem.live/
+- Before: https://main--citisignal-storefront--AdobeDevXSC.aem.live/
+- After: https://<branch>--citisignal-storefront--AdobeDevXSC.aem.live/

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -7,7 +7,9 @@
 
 # Use the following for Doc-based authoring. Make sure to change it to your SharePoint or Google Drive url.
 mountpoints:
-  /: https://adobe.sharepoint.com/:f:/r/sites/CitiSignal/Shared%20Documents/CitiSignal-Storefront-Summit25
+  /:
+    url: https://content.da.live/AdobeDevXSC/citisignal-storefront/
+    type: markup
 
 folders:
   /products/plan/: /products/plan/default


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1 

Test URLs:
- Before: https://main--citisignal-storefront--AdobeDevXSC.aem.live/
- After: https://da--citisignal-storefront--AdobeDevXSC.aem.live/
